### PR TITLE
Return $root element from colorpicker.js

### DIFF
--- a/addon/colorpicker/colorpicker.js
+++ b/addon/colorpicker/colorpicker.js
@@ -1244,6 +1244,7 @@
             isShortCut : function () {
                 return isShortCut;
             },
+            $root: $root,
             show: show,
             hide: hide,
             setColor: setColor,


### PR DESCRIPTION
If someone wishes to manipulate the DOM element of the colorpicker from outside, this would help.

What is my use case?
Currently, colorpicker closes only if we change selection / scroll inside codemirror. But, I wish to close it if the user clicks anywhere on the page, even outside CodeMirror instance. A simple CodeMirror 'blur' won't help here. For now, I'm returning $root and using some delay logic with mouseover/mouseout in my use case @ https://github.com/webextensions/live-css-editor/tree/master/extension/scripts/3rdparty/codemirror/addons/colorpicker

I'll create separate issues for the root problem I mentioned above.