### PR TITLE
Update regex in colorview.js to handle spaces

### DIFF
--- a/addon/colorpicker/colorview.js
+++ b/addon/colorpicker/colorview.js
@@ -291,8 +291,8 @@
         }
     }
 
-    codemirror_colorpicker.prototype.color_regexp = /(#(?:[\da-f]{3}){1,2}|rgb\((?:\d{1,3},\s*){2}\d{1,3}\)|rgba\((?:\d{1,3},\s*){3}\d*\.?\d+\)|hsl\(\d{1,3}(?:,\s*\d{1,3}%){2}\)|hsla\(\d{1,3}(?:,\s*\d{1,3}%){2},\s*\d*\.?\d+\)|(\w+))/gi;
-
+    codemirror_colorpicker.prototype.color_regexp = /(#(?:[\da-f]{3}){1,2}|rgb\((?:\s*\d{1,3},\s*){2}\d{1,3}\s*\)|rgba\((?:\s*\d{1,3},\s*){3}\d*\.?\d+\s*\)|hsl\(\s*\d{1,3}(?:,\s*\d{1,3}%){2}\s*\)|hsla\(\s*\d{1,3}(?:,\s*\d{1,3}%){2},\s*\d*\.?\d+\s*\)|(\w+))/gi;
+    
     codemirror_colorpicker.prototype.match_result = function (lineHandle) {
         return lineHandle.text.match(this.color_regexp);
     }


### PR DESCRIPTION
Previously if you wrote `rgb( 0, 0, 0 )` the regex wouldn't match because of the space just inside the parentheses, causing colorpicker to create and insert a new color declaration: `rgb(0,0,0)( 0, 0, 0 )` ..or something like that.

The patch adds a bunch `\s*` so that the regex matches regardless of formatting.