### PR TITLE
Made has_class function more generic (to fix integration issue with emmet)

### DIFF
--- a/addon/colorpicker/colorview.js
+++ b/addon/colorpicker/colorview.js
@@ -92,8 +92,7 @@
     }
 
     function has_class(el, cls) {
-        if (!el.className)
-        {
+        if (!el || !el.className) {
             return false;
         } else {
             var newClass = ' ' + el.className + ' ';


### PR DESCRIPTION
When I was trying to integrate this plugin into my extension https://github.com/webextensions/live-css-editor while also using the plugin https://github.com/emmetio/codemirror-plugin an error was occuring due to the following piece of code:

function has_class(el, cls) {
        if (!el.className) {
            return false;
        ...
Uncaught TypeError: Cannot read property 'className' of undefined

The "el" passed here was undefined. It was getting called from the following code:
    codemirror_colorpicker.prototype.empty_marker = function (lineNo, lineHandle) {
        ...
        if (key && has_class(list[i].marker.replacedWith, colorpicker_class)) {
        ...

list[i].marker.replacedWith was set as undefined in some cases and hence causing the issue.

Here, in this commit, I have fixed the issue in "has_class" function. Though it can also be fixed at the place where it is being called incorrectly by checking for existence of list[i].marker.replacedWith.

In case you wish to reproduce the issue, use this plugin along with https://github.com/emmetio/codemirror-plugin and try to type the following CSS:
    a { color: red; }
The above mentioned error would be seen. And after this fix, that issue would be gone.