### PR TITLE
support eyedropper

### DIFF
--- a/addon/codemirror-colorpicker.css
+++ b/addon/codemirror-colorpicker.css
@@ -133,6 +133,19 @@
        -moz-user-select: none;
         -ms-user-select: none;
             user-select: none; }
+    .codemirror-colorpicker .colorpicker-body .control.has-eyedropper {
+      padding-left: 30px; }
+      .codemirror-colorpicker .colorpicker-body .control.has-eyedropper .el-cp-color-control__left {
+        position: absolute;
+        left: 12px;
+        top: 20px;
+        width: 30px;
+        height: 30px;
+        border-radius: 50%;
+        -webkit-box-sizing: border-box;
+                box-sizing: border-box; }
+      .codemirror-colorpicker .colorpicker-body .control.has-eyedropper > .color, .codemirror-colorpicker .colorpicker-body .control.has-eyedropper > .empty {
+        left: 45px; }
     .codemirror-colorpicker .colorpicker-body .control > .color, .codemirror-colorpicker .colorpicker-body .control > .empty {
       position: absolute;
       left: 12px;
@@ -532,6 +545,10 @@
       height: 150px; }
     .codemirror-colorpicker.sketch > .colorpicker-body > .control {
       padding: 0px; }
+      .codemirror-colorpicker.sketch > .colorpicker-body > .control.has-eyedropper {
+        padding-left: 30px; }
+        .codemirror-colorpicker.sketch > .colorpicker-body > .control.has-eyedropper .el-cp-color-control__left {
+          top: 4px; }
       .codemirror-colorpicker.sketch > .colorpicker-body > .control > .color, .codemirror-colorpicker.sketch > .colorpicker-body > .control > .empty {
         position: absolute;
         right: 10px;
@@ -715,6 +732,10 @@
     padding-top: 0px; }
     .codemirror-colorpicker.macos .control > .color, .codemirror-colorpicker.macos .control > .empty {
       top: 4px; }
+    .codemirror-colorpicker.macos .control.has-eyedropper {
+      padding-left: 30px; }
+      .codemirror-colorpicker.macos .control.has-eyedropper .el-cp-color-control__left {
+        top: 9px; }
   .codemirror-colorpicker.macos .value {
     position: relative;
     padding: 6px 16px;
@@ -905,6 +926,13 @@
       width: 30px;
       height: 30px;
       border-radius: 2px; }
+    .codemirror-colorpicker.ring .control.has-eyedropper {
+      padding-left: 30px;
+      padding-top: 10px; }
+      .codemirror-colorpicker.ring .control.has-eyedropper > .color, .codemirror-colorpicker.ring .control.has-eyedropper > .empty {
+        top: -2px; }
+      .codemirror-colorpicker.ring .control.has-eyedropper .el-cp-color-control__left {
+        top: 4px; }
   .codemirror-colorpicker.xd {
     display: inline-block;
     padding-top: 12px;
@@ -985,8 +1013,23 @@
       border-radius: 0px;
       display: inline-block; }
       .codemirror-colorpicker.vscode .colorpicker-body .color-view {
-        height: 34px;
-        background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAYAAADED76LAAAAJElEQVQYV2NctWrVfwYkEBYWxojMZ6SDAmT7QGx0K1EcRBsFAADeG/3M/HteAAAAAElFTkSuQmCC") repeat; }
+        height: 34px; }
+        .codemirror-colorpicker.vscode .colorpicker-body .color-view.has-eyedropper {
+          display: -webkit-box;
+          display: -ms-flexbox;
+          display: flex; }
+          .codemirror-colorpicker.vscode .colorpicker-body .color-view.has-eyedropper .color-view-container {
+            width: 254px;
+            display: inline-block; }
+          .codemirror-colorpicker.vscode .colorpicker-body .color-view.has-eyedropper .el-cp-color-control__left {
+            float: right;
+            width: 80px;
+            text-align: center;
+            padding: 6px 0px; }
+            .codemirror-colorpicker.vscode .colorpicker-body .color-view.has-eyedropper .el-cp-color-control__left button {
+              display: inline-block; }
+              .codemirror-colorpicker.vscode .colorpicker-body .color-view.has-eyedropper .el-cp-color-control__left button svg path {
+                fill: white; }
         .codemirror-colorpicker.vscode .colorpicker-body .color-view .color-view-container {
           line-height: 34px;
           font-size: 14px;
@@ -998,7 +1041,11 @@
              -moz-user-select: none;
               -ms-user-select: none;
                   user-select: none;
-          text-shadow: 0 0 3px #535353; }
+          text-shadow: 0 0 3px #535353;
+          background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAYAAADED76LAAAAJElEQVQYV2NctWrVfwYkEBYWxojMZ6SDAmT7QGx0K1EcRBsFAADeG/3M/HteAAAAAElFTkSuQmCC") repeat; }
+          .codemirror-colorpicker.vscode .colorpicker-body .color-view .color-view-container .preview {
+            display: block;
+            height: 100%; }
       .codemirror-colorpicker.vscode .colorpicker-body .color-tool {
         padding: 8px; }
     .codemirror-colorpicker.vscode .color {
@@ -1068,3 +1115,32 @@
       color: white; }
   .colorsets-contextmenu.small .menu-item.small-hide {
     display: none; }
+
+.el-cp-color-eyedropper button {
+  display: block;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  margin: -4px;
+  font-size: 0;
+  border: none;
+  border-radius: var(--size-radius);
+  cursor: pointer;
+  outline: none;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  background: none;
+  -webkit-transition: opacity var(--speed-focus) ease-out, -webkit-box-shadow var(--speed-focus) ease-out;
+  transition: opacity var(--speed-focus) ease-out, -webkit-box-shadow var(--speed-focus) ease-out;
+  transition: box-shadow var(--speed-focus) ease-out, opacity var(--speed-focus) ease-out;
+  transition: box-shadow var(--speed-focus) ease-out, opacity var(--speed-focus) ease-out, -webkit-box-shadow var(--speed-focus) ease-out; }
+  .el-cp-color-eyedropper button:focus-visible {
+    -webkit-box-shadow: 0 0 0 2px var(--color-key);
+            box-shadow: 0 0 0 2px var(--color-key); }
+  .el-cp-color-eyedropper button:active {
+    opacity: .5; }
+
+.el-cp-color-eyedropper svg {
+  display: block;
+  margin: 0 auto;
+  color: var(--color-fill); }

--- a/addon/codemirror-colorpicker.js
+++ b/addon/codemirror-colorpicker.js
@@ -7560,6 +7560,43 @@ var Opacity = function (_BaseSlider) {
     return Opacity;
 }(BaseSlider);
 
+function isSupported(api, apiParent) {
+    return api in apiParent;
+}
+
+var enableEyeDropper = isSupported('EyeDropper', window);
+
+var Eyedropper = function (_UIElement) {
+  inherits(Eyedropper, _UIElement);
+
+  function Eyedropper() {
+    classCallCheck(this, Eyedropper);
+    return possibleConstructorReturn(this, (Eyedropper.__proto__ || Object.getPrototypeOf(Eyedropper)).apply(this, arguments));
+  }
+
+  createClass(Eyedropper, [{
+    key: 'template',
+    value: function template() {
+      return (/*html*/'\n      <nav class="el-cp-color-eyedropper">\n        <button type="button" ref="$button" title="Eyedropper">\n          <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">\n            <path d="M7.797 18.344c-.019.001-.074-.009-.24-.065-.277-.094-.745-.25-1.137.141l-1.542 1.543a.595.595 0 0 1-.84-.84L5.58 17.58c.391-.39.235-.859.141-1.14-.045-.134-.06-.195-.072-.206-.002-.003-.005-.003-.007-.001l1.06-1.06.703.705a.432.432 0 1 0 .611-.611l-.703-.705.557-.557.703.703a.434.434 0 0 0 .611 0 .434.434 0 0 0 0-.61l-.703-.703.571-.572.703.704a.435.435 0 0 0 .612 0 .434.434 0 0 0 0-.61l-.705-.706L14 7.875l2.126 2.127-8.33 8.342zM19.29 9.37l-.654-.655 1.669-1.668a2.372 2.372 0 0 0-3.353-3.354l-1.669 1.669-.655-.654a1.341 1.341 0 0 0-1.898 1.897l.658.658-8.358 8.359c-.373.373-.214.841-.13 1.094.061.18.069.24.069.253l-1.543 1.542a1.458 1.458 0 1 0 2.062 2.061l1.536-1.54c.019-.003.08.006.259.066.252.085.72.243 1.093-.13l8.359-8.358.658.658a1.341 1.341 0 1 0 1.897-1.898z" fill="currentColor"/>\n          </svg>\n        </button>\n      </nav>\n    '
+      );
+    }
+  }, {
+    key: 'click $button',
+    value: function click$button() {
+      var _this2 = this;
+
+      if (enableEyeDropper) {
+        var eyeDropper = new EyeDropper();
+        eyeDropper.open().then(function (result) {
+          _this2.$store.dispatch('/changeColor', result.sRGBHex);
+          _this2.$store.emit('lastUpdateColor');
+        });
+      }
+    }
+  }]);
+  return Eyedropper;
+}(UIElement);
+
 var source = 'macos-control';
 
 var ColorControl = function (_UIElement) {
@@ -7573,12 +7610,16 @@ var ColorControl = function (_UIElement) {
     createClass(ColorControl, [{
         key: 'components',
         value: function components() {
-            return { Value: Value, Opacity: Opacity };
+            return { Value: Value, Opacity: Opacity, Eyedropper: Eyedropper };
         }
     }, {
         key: 'template',
         value: function template() {
-            return '\n        <div class="control">\n            <div target="Value" ></div>\n            <div target="Opacity" ></div>\n            <div ref="$controlPattern" class="empty"></div>\n            <div ref="$controlColor" class="color"></div>\n        </div>\n        ';
+
+            var hasEyeDropper = enableEyeDropper ? 'has-eyedropper' : '';
+            var $eyedropper = !!enableEyeDropper ? '\n        <div class="el-cp-color-control__left">\n          <div target="Eyedropper"></div>\n        </div>\n      ' : '';
+
+            return '\n        <div class="control ' + hasEyeDropper + '">\n            <div target="Value" ></div>\n            <div target="Opacity" ></div>\n            <div ref="$controlPattern" class="empty"></div>\n            <div ref="$controlColor" class="color"></div>\n            ' + $eyedropper + '                       \n        </div>\n        ';
         }
     }, {
         key: 'setBackgroundColor',
@@ -8446,12 +8487,16 @@ var ColorControl$2 = function (_UIElement) {
     createClass(ColorControl, [{
         key: 'components',
         value: function components() {
-            return { Hue: Hue, Opacity: Opacity };
+            return { Hue: Hue, Opacity: Opacity, Eyedropper: Eyedropper };
         }
     }, {
         key: 'template',
         value: function template() {
-            return '\n        <div class="control">\n            <div target="Hue" ></div>\n            <div target="Opacity" ></div>\n            <div ref="$controlPattern" class="empty"></div>\n            <div ref="$controlColor" class="color"></div>\n        </div>\n        ';
+
+            var hasEyeDropper = enableEyeDropper ? 'has-eyedropper' : '';
+            var $eyedropper = !!enableEyeDropper ? '\n        <div class="el-cp-color-control__left">\n          <div target="Eyedropper"></div>\n        </div>\n      ' : '';
+
+            return '\n        <div class="control ' + hasEyeDropper + '">\n            <div target="Hue" ></div>\n            <div target="Opacity" ></div>\n            <div ref="$controlPattern" class="empty"></div>\n            <div ref="$controlColor" class="color"></div>\n            ' + $eyedropper + '            \n        </div>\n        ';
         }
     }, {
         key: 'setBackgroundColor',
@@ -8990,12 +9035,16 @@ var ColorControl$8 = function (_UIElement) {
     createClass(ColorControl, [{
         key: 'components',
         value: function components() {
-            return { Value: Value, Opacity: Opacity };
+            return { Value: Value, Opacity: Opacity, Eyedropper: Eyedropper };
         }
     }, {
         key: 'template',
         value: function template() {
-            return '\n        <div class="control">\n            <div target="Value" ></div>\n            <div target="Opacity" ></div>\n            <div ref="$controlPattern" class="empty"></div>\n            <div ref="$controlColor" class="color"></div>\n        </div>\n        ';
+
+            var hasEyeDropper = enableEyeDropper ? 'has-eyedropper' : '';
+            var $eyedropper = !!enableEyeDropper ? '\n        <div class="el-cp-color-control__left">\n          <div target="Eyedropper"></div>\n        </div>\n      ' : '';
+
+            return '\n        <div class="control ' + hasEyeDropper + '">\n            <div target="Value" ></div>\n            <div target="Opacity" ></div>\n            <div ref="$controlPattern" class="empty"></div>\n            <div ref="$controlColor" class="color"></div>\n            ' + $eyedropper + '                                \n        </div>\n        ';
         }
     }, {
         key: 'setBackgroundColor',
@@ -9267,7 +9316,11 @@ var VSCodePicker = function (_BaseColorPicker) {
     createClass(VSCodePicker, [{
         key: 'template',
         value: function template() {
-            return (/*html*/'\n            <div class=\'colorpicker-body\'>\n                <div class=\'color-view\'>\n                    <div class=\'color-view-container\'  ref="$colorview"></div>\n                </div>\n                <div class=\'color-tool\'>\n                    <div target="palette"></div>\n                    <div target="control"></div>\n                </div>\n            </div>\n        '
+
+            var hasEyeDropper = enableEyeDropper ? 'has-eyedropper' : '';
+            var $eyedropper = !!enableEyeDropper ? '\n        <div class="el-cp-color-control__left">\n          <div target="Eyedropper"></div>\n        </div>\n      ' : '';
+
+            return (/*html*/'\n            <div class=\'colorpicker-body\'>\n                <div class=\'color-view ' + hasEyeDropper + '\' >\n                    <div class=\'color-view-container\'  >\n                        <div class="preview" ref="$colorview"></div>\n                    </div>\n                    ' + $eyedropper + '            \n                </div>\n                <div class=\'color-tool\'>\n                    <div target="palette"></div>\n                    <div target="control"></div>\n                </div>\n            </div>\n        '
             );
         }
     }, {
@@ -9275,7 +9328,8 @@ var VSCodePicker = function (_BaseColorPicker) {
         value: function components() {
             return {
                 palette: ColorPalette,
-                control: ColorControl$12
+                control: ColorControl$12,
+                Eyedropper: Eyedropper
             };
         }
     }, {

--- a/index.html
+++ b/index.html
@@ -633,6 +633,12 @@ var colorpicker = new ColorPicker({
     </div>               
 
     <div class="colorpicker-type">
+        <h3>VSCode Style</h3>
+        <div class="colorpicker-style" data-type="vscode"></div>
+    </div>            
+
+
+    <div class="colorpicker-type">
         <h3>Mini Style</h3>
         <div class="colorpicker-style" data-type="mini"></div>
     </div>    
@@ -642,10 +648,6 @@ var colorpicker = new ColorPicker({
         <div class="colorpicker-style" data-type="mini-vertical"></div>
     </div>        
 
-    <div class="colorpicker-type">
-        <h3>VSCode Style</h3>
-        <div class="colorpicker-style" data-type="vscode"></div>
-    </div>            
      
             
     <!-- <div class="colorpicker-type">

--- a/src/colorpicker/chromedevtool/ColorControl.js
+++ b/src/colorpicker/chromedevtool/ColorControl.js
@@ -1,22 +1,33 @@
+import { enableEyeDropper } from '../../util/functions/support';
 import Hue from '../ui/control/Hue';
 import Opacity from '../ui/control/Opacity'
 import UIElement from '../UIElement';
+import Eyedropper from '../ui/Eyedropper';
 
 const source = 'chromedevtool-control';
 
 export default class ColorControl extends UIElement {
 
     components () {
-        return { Hue, Opacity }
+        return { Hue, Opacity, Eyedropper }
     }
 
     template () {
+
+        const hasEyeDropper = enableEyeDropper ? 'has-eyedropper' : '';
+        let $eyedropper = !!enableEyeDropper ? `
+        <div class="el-cp-color-control__left">
+          <div target="Eyedropper"></div>
+        </div>
+      ` : '';
+
         return `
-        <div class="control">
+        <div class="control ${hasEyeDropper}">
             <div target="Hue" ></div>
             <div target="Opacity" ></div>
             <div ref="$controlPattern" class="empty"></div>
             <div ref="$controlColor" class="color"></div>
+            ${$eyedropper}            
         </div>
         `
     }

--- a/src/colorpicker/macos/ColorControl.js
+++ b/src/colorpicker/macos/ColorControl.js
@@ -1,22 +1,34 @@
 import Value from '../ui/control/Value';
 import UIElement from '../UIElement';
 import Opacity from '../ui/control/Opacity'
+import Eyedropper from '../ui/Eyedropper';
+import { enableEyeDropper } from '../../util/functions/support';
 
 const source = 'macos-control';
 
 export default class ColorControl extends UIElement {
 
     components () {
-        return { Value, Opacity }
+        return { Value, Opacity, Eyedropper }
     } 
 
     template () {
+
+        const hasEyeDropper = enableEyeDropper ? 'has-eyedropper' : '';
+        let $eyedropper = !!enableEyeDropper ? `
+        <div class="el-cp-color-control__left">
+          <div target="Eyedropper"></div>
+        </div>
+      ` : '';
+
+
         return `
-        <div class="control">
+        <div class="control ${hasEyeDropper}">
             <div target="Value" ></div>
             <div target="Opacity" ></div>
             <div ref="$controlPattern" class="empty"></div>
             <div ref="$controlColor" class="color"></div>
+            ${$eyedropper}                       
         </div>
         `
     }

--- a/src/colorpicker/ring/ColorControl.js
+++ b/src/colorpicker/ring/ColorControl.js
@@ -1,22 +1,33 @@
 import Value from '../ui/control/Value';
 import UIElement from '../UIElement';
 import Opacity from '../ui/control/Opacity'
+import { enableEyeDropper } from '../../util/functions/support';
+import Eyedropper from '../ui/Eyedropper';
 
 const source = 'macos-control';
 
 export default class ColorControl extends UIElement {
 
     components () {
-        return { Value, Opacity }
+        return { Value, Opacity, Eyedropper }
     } 
 
     template () {
+
+        const hasEyeDropper = enableEyeDropper ? 'has-eyedropper' : '';
+        let $eyedropper = !!enableEyeDropper ? `
+        <div class="el-cp-color-control__left">
+          <div target="Eyedropper"></div>
+        </div>
+      ` : '';
+
         return `
-        <div class="control">
+        <div class="control ${hasEyeDropper}">
             <div target="Value" ></div>
             <div target="Opacity" ></div>
             <div ref="$controlPattern" class="empty"></div>
             <div ref="$controlColor" class="color"></div>
+            ${$eyedropper}                                
         </div>
         `
     }

--- a/src/colorpicker/ui/Eyedropper.js
+++ b/src/colorpicker/ui/Eyedropper.js
@@ -1,0 +1,32 @@
+
+import UIElement from '../UIElement';
+import './Eyedropper.scss';
+import { enableEyeDropper } from '../../util/functions/support';
+
+export default class Eyedropper extends UIElement {
+
+  template() {
+    return /*html*/`
+      <nav class="el-cp-color-eyedropper">
+        <button type="button" ref="$button" title="Eyedropper">
+          <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+            <path d="M7.797 18.344c-.019.001-.074-.009-.24-.065-.277-.094-.745-.25-1.137.141l-1.542 1.543a.595.595 0 0 1-.84-.84L5.58 17.58c.391-.39.235-.859.141-1.14-.045-.134-.06-.195-.072-.206-.002-.003-.005-.003-.007-.001l1.06-1.06.703.705a.432.432 0 1 0 .611-.611l-.703-.705.557-.557.703.703a.434.434 0 0 0 .611 0 .434.434 0 0 0 0-.61l-.703-.703.571-.572.703.704a.435.435 0 0 0 .612 0 .434.434 0 0 0 0-.61l-.705-.706L14 7.875l2.126 2.127-8.33 8.342zM19.29 9.37l-.654-.655 1.669-1.668a2.372 2.372 0 0 0-3.353-3.354l-1.669 1.669-.655-.654a1.341 1.341 0 0 0-1.898 1.897l.658.658-8.358 8.359c-.373.373-.214.841-.13 1.094.061.18.069.24.069.253l-1.543 1.542a1.458 1.458 0 1 0 2.062 2.061l1.536-1.54c.019-.003.08.006.259.066.252.085.72.243 1.093-.13l8.359-8.358.658.658a1.341 1.341 0 1 0 1.897-1.898z" fill="currentColor"/>
+          </svg>
+        </button>
+      </nav>
+    `;
+  }
+
+  ['click $button']() {
+    if (enableEyeDropper) {
+      const eyeDropper = new EyeDropper();
+      eyeDropper.open().then(result => {
+        this.$store.dispatch('/changeColor', result.sRGBHex);
+        this.$store.emit('lastUpdateColor');        
+      })
+
+
+    }
+  }
+
+}

--- a/src/colorpicker/ui/Eyedropper.scss
+++ b/src/colorpicker/ui/Eyedropper.scss
@@ -1,0 +1,28 @@
+.el-cp-color-eyedropper {
+  button {
+    display: block;
+    width: 30px;
+    height: 30px;
+    padding: 0;
+    margin: -4px;
+    font-size: 0;
+    border: none;
+    border-radius: var(--size-radius);
+    cursor: pointer;
+    outline: none;
+    box-sizing: border-box;
+    background: none;
+    transition: box-shadow var(--speed-focus) ease-out, opacity var(--speed-focus) ease-out;
+    &:focus-visible {
+      box-shadow: 0 0 0 2px var(--color-key);
+    }
+    &:active {
+      opacity: .5;
+    }
+  }
+  svg {
+    display: block;
+    margin: 0 auto;
+    color: var(--color-fill);
+  }
+}

--- a/src/colorpicker/vscode/index.js
+++ b/src/colorpicker/vscode/index.js
@@ -3,14 +3,27 @@ import BaseColorPicker from '../BaseColorPicker'
 import ColorControl from './ColorControl'
 import ColorPalette from '../ui/ColorPalette'
 import Color from '../../util/Color'
+import { enableEyeDropper } from '../../util/functions/support';
+import Eyedropper from '../ui/Eyedropper';
 
 export default class VSCodePicker extends BaseColorPicker {
 
     template () {
+
+        const hasEyeDropper = enableEyeDropper ? 'has-eyedropper' : '';
+        let $eyedropper = !!enableEyeDropper ? `
+        <div class="el-cp-color-control__left">
+          <div target="Eyedropper"></div>
+        </div>
+      ` : '';
+
         return /*html*/`
             <div class='colorpicker-body'>
-                <div class='color-view'>
-                    <div class='color-view-container'  ref="$colorview"></div>
+                <div class='color-view ${hasEyeDropper}' >
+                    <div class='color-view-container'  >
+                        <div class="preview" ref="$colorview"></div>
+                    </div>
+                    ${$eyedropper}            
                 </div>
                 <div class='color-tool'>
                     <div target="palette"></div>
@@ -23,7 +36,8 @@ export default class VSCodePicker extends BaseColorPicker {
     components() {
         return { 
             palette: ColorPalette,  
-            control: ColorControl
+            control: ColorControl,
+            Eyedropper
         }
     }
 

--- a/src/scss/component/control.scss
+++ b/src/scss/component/control.scss
@@ -3,6 +3,25 @@
     padding: 10px 0px 10px 0px;
     user-select: none;
 
+    &.has-eyedropper {
+        padding-left: 30px;
+
+        .el-cp-color-control__left {
+          position: absolute;
+          left: 12px;
+          top: 20px;
+          width: 30px;
+          height: 30px;
+          border-radius: 50%;
+          box-sizing: border-box;
+        }
+
+        > .color, > .empty {
+          left: 45px;
+        }
+    }
+
+
     > .color, > .empty {
       position: absolute;
       left: 12px;

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -2,4 +2,4 @@
 
 @import './colorview';
 @import './colorpicker';
-    
+                                       

--- a/src/scss/themes/macos.scss
+++ b/src/scss/themes/macos.scss
@@ -37,6 +37,15 @@
         > .color, > .empty {
             top: 4px;
         }
+
+        &.has-eyedropper {
+            padding-left: 30px;
+    
+            .el-cp-color-control__left {
+              top: 9px;
+            }
+        }
+    
     }
 
 

--- a/src/scss/themes/ring.scss
+++ b/src/scss/themes/ring.scss
@@ -53,5 +53,19 @@
             height: 30px;
             border-radius: 2px;
         }
+
+
+        &.has-eyedropper {
+            padding-left: 30px;
+            padding-top: 10px;
+    
+            > .color, > .empty {
+                top: -2px;
+            }
+
+            .el-cp-color-control__left {
+              top: 4px;
+            }
+        }        
     }
 }

--- a/src/scss/themes/sketch.scss
+++ b/src/scss/themes/sketch.scss
@@ -11,6 +11,15 @@
     
         > .control {
             padding: 0px;
+
+
+            &.has-eyedropper {
+                padding-left: 30px;
+        
+                .el-cp-color-control__left {
+                  top: 4px;
+                }
+            }            
     
             > .color, > .empty {
                 position: absolute;

--- a/src/scss/themes/vscode.scss
+++ b/src/scss/themes/vscode.scss
@@ -12,7 +12,32 @@
 
         .color-view {
             height: 34px;
-            @include transparent-background();
+
+            &.has-eyedropper {
+                display: flex;
+                .color-view-container {
+                    width: 254px;
+                    display: inline-block;
+                }
+
+                
+                .el-cp-color-control__left {
+                    float: right;
+                    width: 80px;
+                    text-align: center;
+                    padding: 6px 0px;
+                    
+                    button {
+                        display: inline-block;
+
+                        svg {
+                            path {
+                                fill: white;
+                            }
+                        }
+                    }
+                }
+            }
 
             .color-view-container {
                 line-height: 34px;
@@ -23,6 +48,12 @@
                 cursor: pointer;
                 user-select: none;                
                 text-shadow: 0 0 3px rgb(83, 83, 83);
+                @include transparent-background();
+                
+                .preview {
+                    display: block;
+                    height: 100%;
+                }
             }
         }
 

--- a/src/util/functions/support.js
+++ b/src/util/functions/support.js
@@ -1,0 +1,5 @@
+function isSupported(api, apiParent) {
+    return (api in apiParent);
+}
+
+export const enableEyeDropper = isSupported('EyeDropper', window);


### PR DESCRIPTION
EyeDropper can be used since chrome v95

<img width="742" alt="스크린샷 2021-12-11 오후 9 12 05" src="https://user-images.githubusercontent.com/591983/145676240-989f9f30-6f5c-49ce-8789-c917bd19c88c.png">


#45
#42